### PR TITLE
AttributeError: 'RelatedManager' object has no attribute 'prefetch_cache_name'

### DIFF
--- a/tests/testapp/testapp/models.py
+++ b/tests/testapp/testapp/models.py
@@ -5,6 +5,8 @@ from django.db import models
 
 class User(models.Model):
     hobbies = models.ManyToManyField('Hobby', related_name='users')
+    goods = models.ManyToManyField('Good', related_name='owners',
+                                   through='Purchase')
 
 
 class Pet(models.Model):
@@ -25,3 +27,13 @@ class Address(models.Model):
 
 class Hobby(models.Model):
     pass
+
+
+class Good(models.Model):
+    pass
+
+
+class Purchase(models.Model):
+    user = models.ForeignKey(User, related_name='purchases')
+    good = models.ForeignKey(Good)
+    purchased_at = models.DateTimeField(auto_now_add=True)

--- a/tests/testapp/testapp/tests.py
+++ b/tests/testapp/testapp/tests.py
@@ -160,6 +160,9 @@ class TestIntegration:
         assert call.objects == (models.Pet, 'allergy_set')
         assert 'pet.allergy_set' in ''.join(call.frame[4])
 
+    def test_many_to_many_through(self, objects, client):
+        client.get('/many_to_many_through/')
+
     def test_eager_select(self, objects, client, logger):
         client.get('/eager_select/')
         assert not logger.log.called

--- a/tests/testapp/testapp/urls.py
+++ b/tests/testapp/testapp/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^one_to_one/$', views.one_to_one),
     url(r'^many_to_many/$', views.many_to_many),
+    url(r'^many_to_many_through/$', views.many_to_many_through),
     url(r'^eager_select/$', views.eager_select),
     url(r'^eager_prefetch/$', views.eager_prefetch),
     url(r'^eager_prefetch_item/$', views.eager_prefetch_item),

--- a/tests/testapp/testapp/views.py
+++ b/tests/testapp/testapp/views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from django.db.models import Prefetch
 from django.http import HttpResponse
 
 from . import models
@@ -13,6 +14,11 @@ def one_to_one(request):
 def many_to_many(request):
     users = models.User.objects.all()
     return HttpResponse(users[0].hobbies.all())
+
+
+def many_to_many_through(request):
+    users = models.User.objects.prefetch_related(Prefetch('purchases'))
+    return HttpResponse(users[0].purchases.all())
 
 
 def eager_prefetch(request):


### PR DESCRIPTION
Getting the error when using [`django.db.models.Prefetch`](https://docs.djangoproject.com/en/1.8/ref/models/querysets/#django.db.models.Prefetch) to prefetch related `through` model. Error does not occur when `nplusone` is not in `INSTALLED_APPS`.

Test fails on all tox envs.
