### PR TITLE
[django] Change the place of `NPlusOneMiddleware`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,8 @@ Add ``nplusone`` to ``INSTALLED_APPS``: ::
 Add ``NPlusOneMiddleware``: ::
 
     MIDDLEWARE_CLASSES = (
-        ...
         'nplusone.ext.django.NPlusOneMiddleware',
+        ...
     )
 
 Optionally configure logging settings: ::


### PR DESCRIPTION
When the `NPlusOneMiddleware` is at the end of the list of middlewares and a previous middleware returned a response, an error occurs in `NPlusOneMiddleware.process_response` because the request is not the list of listeners, as the `NPlusOneMiddleware.process_request` was not called (because a middleware returning a response stops the execution of the `process_request` methods of the following middlewares)

So the `NPlusOneMiddleware` should be before every middleware that can return a response (or, at least, manage `KeyError` exceptions in `NPlusOneMiddleware.process_response`)