### PR TITLE
Use MiddlewareMixin to fix a deprecation warning on Django 1.10

### DIFF
--- a/nplusone/ext/django/middleware.py
+++ b/nplusone/ext/django/middleware.py
@@ -6,6 +6,11 @@ import six
 
 from django.conf import settings
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
 from nplusone.core import listeners
 from nplusone.core import notifiers
 
@@ -21,7 +26,7 @@ class DjangoRule(listeners.Rule):
         )
 
 
-class NPlusOneMiddleware(object):
+class NPlusOneMiddleware(MiddlewareMixin):
 
     def __init__(self):
         self.listeners = weakref.WeakKeyDictionary()

--- a/tests/testapp/testapp/settings.py
+++ b/tests/testapp/testapp/settings.py
@@ -14,6 +14,8 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 import os
 import logging
 
+import django
+
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
@@ -42,7 +44,7 @@ INSTALLED_APPS = (
     'testapp',
 )
 
-MIDDLEWARE_CLASSES = (
+_middleware_classes = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -52,6 +54,11 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'nplusone.ext.django.NPlusOneMiddleware',
 )
+
+if django.VERSION >= (1, 10):
+    MIDDLEWARE = _middleware_classes
+else:
+    MIDDLEWARE_CLASSES = _middleware_classes
 
 ROOT_URLCONF = 'testapp.urls'
 


### PR DESCRIPTION
This adds `MiddlewareMixin` which is needed to use the Django mixin in the new `MIDDLEWARE` setting instead of the deprecated `MIDDLEWARE_CLASSES`. Here's the relevant Django documentation: https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware