### PR TITLE
Fix license in package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     package_dir={'nplusone': 'nplusone'},
     include_package_data=True,
     install_requires=REQUIRES,
-    license=read('LICENSE'),
+    license='MIT',
     zip_safe=False,
     keywords='nplusone',
     classifiers=[


### PR DESCRIPTION
PyPI expects an OSI-specified license--not the full license text.

Just noticed this while glancing at OSF's pyup:

<img width="700" alt="image" src="https://user-images.githubusercontent.com/2379650/43402802-875454ca-93e1-11e8-90a0-b302c72f925f.png">

P.S. No idea why pyup thinks nplusone isn't Py3-compatible since the correct classifiers are set.
