### PR TITLE
Prevent AttributeError when listeners not present on Flask.g

### DIFF
--- a/nplusone/ext/flask_sqlalchemy.py
+++ b/nplusone/ext/flask_sqlalchemy.py
@@ -48,7 +48,7 @@ class NPlusOne(object):
         @app.after_request
         def disconnect(response):
             for name in six.iterkeys(listeners.listeners):
-                listener = g.listeners.pop(name, None)
+                listener = g.get('listeners', {}).pop(name, None)
                 if listener:
                     listener.teardown()
             return response


### PR DESCRIPTION
When `listeners` not present on [Flask.g](https://flask.palletsprojects.com/en/1.1.x/api/#flask.g) (connect was unable to run) then accessing that attribute raises exception:

`AttributeError: '_AppCtxGlobals' object has no attribute 'listeners'`

Checking that `listeners` exists first fixes the bug.