### PR TITLE
Add warning notifier

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,14 @@ By default, ``nplusone`` logs all potentially unnecessary queries using a logger
 
 The exception type can also be specified, if desired, using the ``NPLUSONE_ERROR`` option.
 
+When the `NPLUSONE_WARNINGS` configuration option is set, ``nplusone`` issues a warning using python warnings library. ::
+    # Django config
+    NPLUSONE_WARNINGS = True
+
+    # Flask config
+    app.config['NPLUSONE_WARNINGS'] = True
+
+
 Ignoring notifications
 **********************
 

--- a/nplusone/core/notifiers.py
+++ b/nplusone/core/notifiers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import warnings
 
 from nplusone.core import exceptions
 
@@ -50,6 +51,15 @@ class ErrorNotifier(Notifier):
 
     def notify(self, message):
         raise self.error(message.message)
+
+
+class WarningNotifier(Notifier):
+
+    CONFIG_KEY = 'NPLUSONE_WARNINGS'
+    ENABLED_DEFAULT = False
+
+    def notify(self, message):
+        warnings.warn(message.message)
 
 
 def init(config):


### PR DESCRIPTION
Using warnings about n+1 query is more pythonic.
> [warnings.warn()](https://docs.python.org/3/library/warnings.html#warnings.warn) in library code if the issue is avoidable and the client application should be modified to eliminate the warning
[logging.warning()](https://docs.python.org/3/library/logging.html#logging.warning) if there is nothing the client application can do about the situation, but the event should still be noted

https://docs.python.org/3/howto/logging.html#when-to-use-logging

It is also convenient to use with pytest. Because pytest creates a report on all warnings. https://docs.pytest.org/en/7.1.x/how-to/capture-warnings.html


Sorry for my english.