### PR TITLE
feat(pytest): add report generation and pytest plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,23 @@ Generating a report
 Using the pytest plugin
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The easiest way to get a report is via the built-in pytest plugin. Add ``--nplusone-report`` to your pytest invocation: ::
+The built-in pytest plugin exposes these flags (any order; they can be combined):
+
+* ``--nplusone`` — run lazy/eager listeners around each test; violations are logged as warnings (unless you add ``--nplusone-error`` or ``--nplusone-report``).
+* ``--nplusone-error`` — raise ``NPlusOneError`` on violations (fail the test). Can be used alone, with ``--nplusone``, or with ``--nplusone-report`` (issues are recorded to the report, then the test fails).
+* ``--nplusone-report`` — aggregate detected issues into a report (terminal summary unless a file is set).
+* ``--nplusone-report-file`` — write the report to a path instead of printing it. The format is inferred from the filename: paths ending in ``.json`` are written as JSON; all other paths use plain text. Terminal-only summaries (no file) are always plain text (for example ``pytest --nplusone-report --nplusone-report-file=report.txt`` or ``report.json``).
+* ``--nplusone-django`` — import ``nplusone.ext.django`` so the Django ORM is patched (requires Django).
+
+``--nplusone-report`` alone enables listeners and the report. For an explicit full stack with Django: ::
+
+    pytest --nplusone --nplusone-report --nplusone-django
+
+To fail the run on the first n+1: ::
+
+    pytest --nplusone --nplusone-error
+
+A minimal report-only invocation: ::
 
     pytest --nplusone-report
 
@@ -191,15 +207,6 @@ This prints a summary at the end of the test run: ::
          - /app/example_tests.py:29
        Tests:
          - example_tests.py::test_n_plus_one_on_pets
-
-To write the report to a file instead of the terminal: ::
-
-    pytest --nplusone-report --nplusone-report-file=report.txt
-
-To get JSON output: ::
-
-    pytest --nplusone-report --nplusone-report-format=json
-    pytest --nplusone-report --nplusone-report-format=json --nplusone-report-file=report.json
 
 The JSON output looks like: ::
 

--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,126 @@ The integrations above are coupled to the request-response cycle. To use ``nplus
     with profiler.Profiler():
         ...
 
+Generating a report
+*******************
+
+``nplusone`` can generate an aggregated report of all detected issues, grouped by model, field, error type, and calling method, with counts and source locations.
+
+Using the pytest plugin
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The easiest way to get a report is via the built-in pytest plugin. Add ``--nplusone-report`` to your pytest invocation: ::
+
+    pytest --nplusone-report
+
+This prints a summary at the end of the test run: ::
+
+    nplusone Report
+    ============================================================
+    Total issues: 9
+    Unique groups: 3
+
+    1. Potential n+1 query detected on `User.hobbies`
+       Model:      User
+       Field:      hobbies
+       Error type: n_plus_one
+       Caller:     test_n_plus_one_on_hobbies
+       Count:      3
+       Locations:
+         - /app/example_tests.py:44
+       Tests:
+         - example_tests.py::test_n_plus_one_on_hobbies
+
+    2. Potential n+1 query detected on `User.occupation`
+       Model:      User
+       Field:      occupation
+       Error type: n_plus_one
+       Caller:     test_n_plus_one_on_occupation
+       Count:      3
+       Locations:
+         - /app/example_tests.py:36
+       Tests:
+         - example_tests.py::test_n_plus_one_on_occupation
+
+    3. Potential n+1 query detected on `User.pet_set`
+       Model:      User
+       Field:      pet_set
+       Error type: n_plus_one
+       Caller:     test_n_plus_one_on_pets
+       Count:      3
+       Locations:
+         - /app/example_tests.py:29
+       Tests:
+         - example_tests.py::test_n_plus_one_on_pets
+
+To write the report to a file instead of the terminal: ::
+
+    pytest --nplusone-report --nplusone-report-file=report.txt
+
+To get JSON output: ::
+
+    pytest --nplusone-report --nplusone-report-format=json
+    pytest --nplusone-report --nplusone-report-format=json --nplusone-report-file=report.json
+
+The JSON output looks like: ::
+
+    {
+      "total_issues": 9,
+      "groups": [
+        {
+          "model": "User",
+          "field": "hobbies",
+          "error_type": "n_plus_one",
+          "caller": "test_n_plus_one_on_hobbies",
+          "count": 3,
+          "message": "Potential n+1 query detected on `User.hobbies`",
+          "locations": ["/app/example_tests.py:44"],
+          "tests": ["example_tests.py::test_n_plus_one_on_hobbies"]
+        }
+      ]
+    }
+
+Using the Profiler
+^^^^^^^^^^^^^^^^^^
+
+To generate a report outside of pytest, pass a ``Report`` object to the ``Profiler``: ::
+
+    from nplusone.core.profiler import Profiler
+    from nplusone.core.report import Report
+    import nplusone.ext.django  # or nplusone.ext.sqlalchemy
+
+    report = Report()
+    with Profiler(report=report):
+        # code that triggers queries
+        ...
+
+    print(report.to_text())   # human-readable summary
+    print(report.to_json())   # JSON output
+    data = report.to_dict()   # Python dict
+
+Using Django or Flask settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Enable the ``ReportNotifier`` by setting ``NPLUSONE_REPORT`` in your settings. Provide a shared ``Report`` instance via ``NPLUSONE_REPORT_OBJECT`` to collect results: ::
+
+    # Django settings.py
+    from nplusone.core.report import Report
+
+    nplusone_report = Report()
+    NPLUSONE_REPORT = True
+    NPLUSONE_REPORT_OBJECT = nplusone_report
+
+    # Flask config
+    from nplusone.core.report import Report
+
+    report = Report()
+    app.config['NPLUSONE_REPORT'] = True
+    app.config['NPLUSONE_REPORT_OBJECT'] = report
+
+After the request cycle, access the collected data: ::
+
+    print(nplusone_report.to_text())
+
 Customizing notifications
 *************************
 

--- a/README.rst
+++ b/README.rst
@@ -153,7 +153,10 @@ The built-in pytest plugin exposes these flags (any order; they can be combined)
 * ``--nplusone`` — run lazy/eager listeners around each test; violations are logged as warnings (unless you add ``--nplusone-error`` or ``--nplusone-report``).
 * ``--nplusone-error`` — raise ``NPlusOneError`` on violations (fail the test). Can be used alone, with ``--nplusone``, or with ``--nplusone-report`` (issues are recorded to the report, then the test fails).
 * ``--nplusone-report`` — aggregate detected issues into a report (terminal summary unless a file is set).
-* ``--nplusone-report-file`` — write the report to a path instead of printing it. The format is inferred from the filename: paths ending in ``.json`` are written as JSON; all other paths use plain text. Terminal-only summaries (no file) are always plain text (for example ``pytest --nplusone-report --nplusone-report-file=report.txt`` or ``report.json``).
+* ``--nplusone-report-file`` — write the report to a path instead of printing it. The format is inferred from the filename: paths ending in ``.json`` are written as JSON; all other paths use plain text. 
+    Terminal-only summaries (no file) are always plain text (for example ``pytest --nplusone-report --nplusone-report-file=report.txt`` or ``report.json``). 
+    Each run adds a unique suffix to the basename (before the extension), so ``report.json`` becomes something like ``report-a1b2c3d4e5f67890.json`` and parallel or repeated runs do not overwrite the same path. 
+    To place the suffix yourself, include the literal substring ``{suffix}`` in the path (for example ``artifacts/{suffix}.json`` or ``run-{suffix}-nplusone.txt``); parent directories are created when needed.
 * ``--nplusone-django`` — import ``nplusone.ext.django`` so the Django ORM is patched (requires Django).
 
 ``--nplusone-report`` alone enables listeners and the report. For an explicit full stack with Django: ::

--- a/nplusone/core/notifiers.py
+++ b/nplusone/core/notifiers.py
@@ -3,6 +3,8 @@
 import logging
 
 from nplusone.core import exceptions
+from nplusone.core import stack
+from nplusone.core.report import Report
 
 
 class Notifier(object):
@@ -52,8 +54,28 @@ class ErrorNotifier(Notifier):
         raise self.error(message.message)
 
 
+class ReportNotifier(Notifier):
+
+    CONFIG_KEY = 'NPLUSONE_REPORT'
+    ENABLED_DEFAULT = False
+
+    CALLER_PATTERNS = [
+        'site-packages', 'nplusone/core', 'nplusone/ext',
+    ]
+
+    def __init__(self, config):
+        self.report = config.get('NPLUSONE_REPORT_OBJECT', Report())
+        self.caller_patterns = config.get(
+            'NPLUSONE_REPORT_CALLER_PATTERNS', self.CALLER_PATTERNS
+        )
+
+    def notify(self, message):
+        caller = stack.get_caller(patterns=self.caller_patterns)
+        self.report.add(message, caller)
+
+
 def init(config):
     return [
-        notifier(config) for notifier in (LogNotifier, ErrorNotifier)
+        notifier(config) for notifier in (LogNotifier, ErrorNotifier, ReportNotifier)
         if notifier.is_enabled(config)
     ]

--- a/nplusone/core/profiler.py
+++ b/nplusone/core/profiler.py
@@ -4,21 +4,29 @@ import six
 
 from nplusone.core import listeners
 from nplusone.core import exceptions
+from nplusone.core import stack
+from nplusone.core.report import Report
 
 
 class Profiler(object):
 
-    def __init__(self, whitelist=None):
+    CALLER_PATTERNS = [
+        'site-packages', 'nplusone/core', 'nplusone/ext',
+    ]
+
+    def __init__(self, whitelist=None, report=None):
         self.whitelist = [
             listeners.Rule(**item)
             for item in (whitelist or [])
         ]
+        self.report = report
 
     def __enter__(self):
         self.listeners = {}
         for name, listener_type in six.iteritems(listeners.listeners):
             self.listeners[name] = listener_type(self)
             self.listeners[name].setup()
+        return self
 
     def __exit__(self, *exc):
         for name in six.iterkeys(listeners.listeners):
@@ -26,4 +34,8 @@ class Profiler(object):
 
     def notify(self, message):
         if not message.match(self.whitelist):
-            raise exceptions.NPlusOneError(message.message)
+            if self.report is not None:
+                caller = stack.get_caller(patterns=self.CALLER_PATTERNS)
+                self.report.add(message, caller)
+            else:
+                raise exceptions.NPlusOneError(message.message)

--- a/nplusone/core/report.py
+++ b/nplusone/core/report.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+
+import json
+from collections import defaultdict
+
+from nplusone.core import stack
+
+
+class ReportEntry(object):
+
+    def __init__(self, message, caller=None, test_name=None):
+        self.model = message.model.__name__
+        self.field = message.field
+        self.label = message.label
+        self.message = message.message
+        self.caller = self._parse_caller(caller)
+        self.test_name = test_name
+
+    @staticmethod
+    def _parse_caller(caller):
+        if caller is None:
+            return None
+        return {
+            'filename': caller[1],
+            'lineno': caller[2],
+            'function': caller[3],
+        }
+
+    @property
+    def group_key(self):
+        caller_func = self.caller['function'] if self.caller else 'unknown'
+        return (self.model, self.field, self.label, caller_func)
+
+
+class Report(object):
+
+    def __init__(self):
+        self.entries = []
+        self._current_test = None
+
+    def set_current_test(self, test_name):
+        self._current_test = test_name
+
+    def clear_current_test(self):
+        self._current_test = None
+
+    def add(self, message, caller=None):
+        self.entries.append(
+            ReportEntry(message, caller, test_name=self._current_test)
+        )
+
+    @property
+    def aggregated(self):
+        groups = defaultdict(list)
+        for entry in self.entries:
+            groups[entry.group_key].append(entry)
+        result = []
+        for (model, field, label, caller_func), entries in sorted(groups.items()):
+            callers = []
+            tests = []
+            for entry in entries:
+                if entry.caller:
+                    callers.append('{filename}:{lineno}'.format(**entry.caller))
+                if entry.test_name:
+                    tests.append(entry.test_name)
+            result.append({
+                'model': model,
+                'field': field,
+                'error_type': label,
+                'caller': caller_func,
+                'count': len(entries),
+                'message': entries[0].message,
+                'locations': sorted(set(callers)),
+                'tests': sorted(set(tests)),
+            })
+        return result
+
+    def to_text(self):
+        lines = []
+        aggregated = self.aggregated
+        if not aggregated:
+            return 'No n+1 issues detected.'
+        lines.append('nplusone Report')
+        lines.append('=' * 60)
+        lines.append('Total issues: {0}'.format(len(self.entries)))
+        lines.append('Unique groups: {0}'.format(len(aggregated)))
+        lines.append('')
+        for i, group in enumerate(aggregated, 1):
+            lines.append('{0}. {1}'.format(i, group['message']))
+            lines.append('   Model:      {0}'.format(group['model']))
+            lines.append('   Field:      {0}'.format(group['field']))
+            lines.append('   Error type: {0}'.format(group['error_type']))
+            lines.append('   Caller:     {0}'.format(group['caller']))
+            lines.append('   Count:      {0}'.format(group['count']))
+            if group['locations']:
+                lines.append('   Locations:')
+                for loc in group['locations']:
+                    lines.append('     - {0}'.format(loc))
+            if group['tests']:
+                lines.append('   Tests:')
+                for test in group['tests']:
+                    lines.append('     - {0}'.format(test))
+            lines.append('')
+        return '\n'.join(lines)
+
+    def to_dict(self):
+        return {
+            'total_issues': len(self.entries),
+            'groups': self.aggregated,
+        }
+
+    def to_json(self, **kwargs):
+        return json.dumps(self.to_dict(), **kwargs)
+
+    def __len__(self):
+        return len(self.entries)
+
+    def __bool__(self):
+        return bool(self.entries)
+
+    __nonzero__ = __bool__

--- a/nplusone/core/report.py
+++ b/nplusone/core/report.py
@@ -6,8 +6,68 @@ from collections import defaultdict
 from nplusone.core import stack
 
 
-class ReportEntry(object):
+def merge_report_dicts(dicts):
+    if not dicts:
+        return {"total_issues": 0, "groups": []}
+    merged_groups = {}
+    total_issues = 0
+    for d in dicts:
+        total_issues += d.get("total_issues", 0)
+        for g in d.get("groups", []):
+            key = (g["model"], g["field"], g["error_type"], g["caller"])
+            if key not in merged_groups:
+                merged_groups[key] = {
+                    "model": g["model"],
+                    "field": g["field"],
+                    "error_type": g["error_type"],
+                    "caller": g["caller"],
+                    "count": g["count"],
+                    "message": g["message"],
+                    "locations": sorted(set(g.get("locations") or [])),
+                    "tests": sorted(set(g.get("tests") or [])),
+                }
+            else:
+                m = merged_groups[key]
+                m["count"] += g["count"]
+                m["locations"] = sorted(set(m["locations"]) | set(g.get("locations") or []))
+                m["tests"] = sorted(set(m["tests"]) | set(g.get("tests") or []))
+    groups = sorted(
+        merged_groups.values(),
+        key=lambda x: (x["model"], x["field"], x["error_type"], x["caller"]),
+    )
+    return {"total_issues": total_issues, "groups": groups}
 
+
+def report_dict_to_text(data):
+    aggregated = data.get("groups") or []
+    if not aggregated:
+        return "No n+1 issues detected."
+    lines = []
+    lines.append("nplusone Report")
+    lines.append("=" * 60)
+    lines.append("Total issues: {0}".format(data.get("total_issues", 0)))
+    lines.append("Unique groups: {0}".format(len(aggregated)))
+    lines.append("")
+    for i, group in enumerate(aggregated, 1):
+        lines.append("{0}. {1}".format(i, group["message"]))
+        lines.append("   Model:      {0}".format(group["model"]))
+        lines.append("   Field:      {0}".format(group["field"]))
+        lines.append("   Error type: {0}".format(group["error_type"]))
+        lines.append("   Caller:     {0}".format(group["caller"]))
+        lines.append("   Count:      {0}".format(group["count"]))
+        if group["locations"]:
+            lines.append("   Locations:")
+            for loc in group["locations"]:
+                lines.append("     - {0}".format(loc))
+        if group["tests"]:
+            lines.append("   Tests:")
+            for test in group["tests"]:
+                lines.append("     - {0}".format(test))
+        lines.append("")
+    return "\n".join(lines)
+
+
+class ReportEntry(object):
     def __init__(self, message, caller=None, test_name=None):
         self.model = message.model.__name__
         self.field = message.field
@@ -21,19 +81,18 @@ class ReportEntry(object):
         if caller is None:
             return None
         return {
-            'filename': caller[1],
-            'lineno': caller[2],
-            'function': caller[3],
+            "filename": caller[1],
+            "lineno": caller[2],
+            "function": caller[3],
         }
 
     @property
     def group_key(self):
-        caller_func = self.caller['function'] if self.caller else 'unknown'
+        caller_func = self.caller["function"] if self.caller else "unknown"
         return (self.model, self.field, self.label, caller_func)
 
 
 class Report(object):
-
     def __init__(self):
         self.entries = []
         self._current_test = None
@@ -45,9 +104,7 @@ class Report(object):
         self._current_test = None
 
     def add(self, message, caller=None):
-        self.entries.append(
-            ReportEntry(message, caller, test_name=self._current_test)
-        )
+        self.entries.append(ReportEntry(message, caller, test_name=self._current_test))
 
     @property
     def aggregated(self):
@@ -60,53 +117,30 @@ class Report(object):
             tests = []
             for entry in entries:
                 if entry.caller:
-                    callers.append('{filename}:{lineno}'.format(**entry.caller))
+                    callers.append("{filename}:{lineno}".format(**entry.caller))
                 if entry.test_name:
                     tests.append(entry.test_name)
-            result.append({
-                'model': model,
-                'field': field,
-                'error_type': label,
-                'caller': caller_func,
-                'count': len(entries),
-                'message': entries[0].message,
-                'locations': sorted(set(callers)),
-                'tests': sorted(set(tests)),
-            })
+            result.append(
+                {
+                    "model": model,
+                    "field": field,
+                    "error_type": label,
+                    "caller": caller_func,
+                    "count": len(entries),
+                    "message": entries[0].message,
+                    "locations": sorted(set(callers)),
+                    "tests": sorted(set(tests)),
+                }
+            )
         return result
 
     def to_text(self):
-        lines = []
-        aggregated = self.aggregated
-        if not aggregated:
-            return 'No n+1 issues detected.'
-        lines.append('nplusone Report')
-        lines.append('=' * 60)
-        lines.append('Total issues: {0}'.format(len(self.entries)))
-        lines.append('Unique groups: {0}'.format(len(aggregated)))
-        lines.append('')
-        for i, group in enumerate(aggregated, 1):
-            lines.append('{0}. {1}'.format(i, group['message']))
-            lines.append('   Model:      {0}'.format(group['model']))
-            lines.append('   Field:      {0}'.format(group['field']))
-            lines.append('   Error type: {0}'.format(group['error_type']))
-            lines.append('   Caller:     {0}'.format(group['caller']))
-            lines.append('   Count:      {0}'.format(group['count']))
-            if group['locations']:
-                lines.append('   Locations:')
-                for loc in group['locations']:
-                    lines.append('     - {0}'.format(loc))
-            if group['tests']:
-                lines.append('   Tests:')
-                for test in group['tests']:
-                    lines.append('     - {0}'.format(test))
-            lines.append('')
-        return '\n'.join(lines)
+        return report_dict_to_text(self.to_dict())
 
     def to_dict(self):
         return {
-            'total_issues': len(self.entries),
-            'groups': self.aggregated,
+            "total_issues": len(self.entries),
+            "groups": self.aggregated,
         }
 
     def to_json(self, **kwargs):

--- a/nplusone/core/signals.py
+++ b/nplusone/core/signals.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import functools
 import contextlib
+import functools
 
 import blinker
+from blinker import ANY
 
 
 load = blinker.Signal()
@@ -14,7 +15,7 @@ touch = blinker.Signal()
 
 
 def get_worker(*args, **kwargs):
-    return blinker.ANY
+    return ANY
 
 
 def signalify(signal, func, parser=None, **context):
@@ -30,6 +31,7 @@ def signalify(signal, func, parser=None, **context):
             parser=parser,
         )
         return ret
+
     return wrapped
 
 
@@ -38,6 +40,7 @@ def designalify(signal, func):
     def wrapped(*args, **kwargs):
         with ignore(signal):
             return func(*args, **kwargs)
+
     return wrapped
 
 
@@ -45,10 +48,16 @@ def designalify(signal, func):
 def ignore(signal, sender=None):
     sender = sender or get_worker()
     receivers = list(signal.receivers_for(sender))
+    reconnect = []
     for receiver in receivers:
         signal.disconnect(receiver, sender=sender)
+        if receiver in list(signal.receivers_for(sender)):
+            signal.disconnect(receiver, sender=ANY)
+            reconnect.append((receiver, ANY))
+        else:
+            reconnect.append((receiver, sender))
     try:
         yield
     finally:
-        for receiver in receivers:
-            signal.connect(receiver, sender=sender)
+        for receiver, reg_sender in reconnect:
+            signal.connect(receiver, sender=reg_sender)

--- a/nplusone/core/stack.py
+++ b/nplusone/core/stack.py
@@ -2,7 +2,7 @@
 
 import inspect
 
-PATTERNS = ['site-packages', 'py.test', 'nplusone']
+PATTERNS = ['site-packages', 'py.test', 'nplusone/core', 'nplusone/ext']
 
 
 def get_caller(patterns=None):

--- a/nplusone/ext/pytest_plugin.py
+++ b/nplusone/ext/pytest_plugin.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import pytest
+
+from nplusone.core.report import Report
+from nplusone.core import listeners
+from nplusone.core import stack
+
+
+_report = Report()
+
+
+class _ReportListener(object):
+
+    CALLER_PATTERNS = [
+        'site-packages', 'nplusone/core', 'nplusone/ext',
+    ]
+
+    def __init__(self, report):
+        self.report = report
+
+    def notify(self, message):
+        caller = stack.get_caller(patterns=self.CALLER_PATTERNS)
+        self.report.add(message, caller)
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup('nplusone')
+    group.addoption(
+        '--nplusone-report',
+        action='store_true',
+        default=False,
+        dest='nplusone_report',
+        help='Generate an nplusone report of n+1 query issues detected during tests.',
+    )
+    group.addoption(
+        '--nplusone-report-file',
+        action='store',
+        default=None,
+        dest='nplusone_report_file',
+        help='Write the nplusone report to a file (default: print to terminal).',
+    )
+    group.addoption(
+        '--nplusone-report-format',
+        action='store',
+        default='text',
+        dest='nplusone_report_format',
+        choices=['text', 'json'],
+        help='Report output format: text or json (default: text).',
+    )
+
+
+def pytest_configure(config):
+    if not config.getoption('nplusone_report', default=False):
+        return
+    global _report
+    _report = Report()
+    config._nplusone_report = _report
+    config._nplusone_listener_parent = _ReportListener(_report)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_protocol(item, nextitem):
+    report = getattr(item.config, '_nplusone_report', None)
+    if report is None:
+        yield
+        return
+
+    parent = item.config._nplusone_listener_parent
+    report.set_current_test(item.nodeid)
+    active_listeners = {}
+    for name, listener_type in listeners.listeners.items():
+        active_listeners[name] = listener_type(parent)
+        active_listeners[name].setup()
+    try:
+        yield
+    finally:
+        for name in list(active_listeners):
+            active_listeners.pop(name).teardown()
+        report.clear_current_test()
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    report = getattr(config, '_nplusone_report', None)
+    if report is None:
+        return
+
+    fmt = config.getoption('nplusone_report_format', default='text')
+    outfile = config.getoption('nplusone_report_file', default=None)
+
+    if fmt == 'json':
+        content = report.to_json(indent=2)
+    else:
+        content = report.to_text()
+
+    if outfile:
+        with open(outfile, 'w') as f:
+            f.write(content)
+            f.write('\n')
+        terminalreporter.write_line(
+            'nplusone report written to: {0}'.format(outfile)
+        )
+    else:
+        terminalreporter.write_line('')
+        terminalreporter.write_line(content)

--- a/nplusone/ext/pytest_plugin.py
+++ b/nplusone/ext/pytest_plugin.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+import os
+import uuid
 
 import pytest
 
@@ -18,11 +20,29 @@ def _is_xdist_worker(config):
     return getattr(config, "workerinput", None) is not None
 
 
-def _infer_report_format(config):
-    outfile = config.getoption("nplusone_report_file", default=None)
-    if outfile and str(outfile).lower().endswith(".json"):
+def _infer_report_format(outfile_path):
+    if outfile_path and str(outfile_path).lower().endswith(".json"):
         return "json"
     return "text"
+
+
+def _ensure_report_file_suffix(config):
+    """Unique per-session token so default report paths are not clobbered."""
+    if getattr(config, "_nplusone_report_file_suffix", None) is None:
+        config._nplusone_report_file_suffix = uuid.uuid4().hex[:16]
+    return config._nplusone_report_file_suffix
+
+
+def _resolve_nplusone_report_file(config):
+    raw = config.getoption("nplusone_report_file", default=None)
+    if not raw:
+        return None
+    raw = os.path.expanduser(os.path.expandvars(str(raw)))
+    suffix = _ensure_report_file_suffix(config)
+    if "{suffix}" in raw:
+        return raw.replace("{suffix}", suffix)
+    base, ext = os.path.splitext(raw)
+    return "{0}-{1}{2}".format(base, suffix, ext)
 
 
 def _ensure_nplusone_django():
@@ -163,7 +183,10 @@ def pytest_addoption(parser):
         dest="nplusone_report_file",
         help=(
             "Write the nplusone report to a file (default: print to terminal). "
-            "Format is inferred from the path: names ending in .json are JSON; otherwise plain text."
+            "Format is inferred from the path: names ending in .json are JSON; otherwise plain text. "
+            "A unique suffix is appended to the basename (before the extension) so repeated runs "
+            "do not overwrite the same file. Use the literal substring {suffix} in the path to insert "
+            "that suffix yourself (for example reports/{suffix}.json or {suffix}-nplusone.txt)."
         ),
     )
 
@@ -250,8 +273,8 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if report is None:
         return
 
-    fmt = _infer_report_format(config)
-    outfile = config.getoption("nplusone_report_file", default=None)
+    outfile = _resolve_nplusone_report_file(config)
+    fmt = _infer_report_format(outfile)
 
     payloads = list(getattr(config, "_nplusone_worker_payloads", None) or [])
     if report.entries:
@@ -269,6 +292,9 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
             content = report_dict_to_text({"total_issues": 0, "groups": []})
 
     if outfile:
+        parent = os.path.dirname(os.path.abspath(outfile))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
         with open(outfile, "w") as f:
             f.write(content)
             f.write("\n")

--- a/nplusone/ext/pytest_plugin.py
+++ b/nplusone/ext/pytest_plugin.py
@@ -1,21 +1,52 @@
 # -*- coding: utf-8 -*-
 
-import os
+import json
+import logging
 
 import pytest
 
-from nplusone.core.report import Report
-from nplusone.core import listeners
-from nplusone.core import stack
+from nplusone.core import exceptions, listeners, stack
+from nplusone.core.report import Report, merge_report_dicts, report_dict_to_text
 
 
 _report = Report()
 
+_django_nplusone_loaded = False
+
+
+def _is_xdist_worker(config):
+    return getattr(config, "workerinput", None) is not None
+
+
+def _infer_report_format(config):
+    outfile = config.getoption("nplusone_report_file", default=None)
+    if outfile and str(outfile).lower().endswith(".json"):
+        return "json"
+    return "text"
+
+
+def _ensure_nplusone_django():
+    global _django_nplusone_loaded
+    if _django_nplusone_loaded:
+        return
+    try:
+        from django.conf import settings
+    except ImportError:
+        return
+    if not settings.configured:
+        return
+    try:
+        import nplusone.ext.django  # noqa: F401
+    except ImportError:
+        return
+    _django_nplusone_loaded = True
+
 
 class _ReportListener(object):
-
     CALLER_PATTERNS = [
-        'site-packages', 'nplusone/core', 'nplusone/ext',
+        "site-packages",
+        "nplusone/core",
+        "nplusone/ext",
     ]
 
     def __init__(self, report):
@@ -26,50 +57,162 @@ class _ReportListener(object):
         self.report.add(message, caller)
 
 
+class _WarnListener(object):
+    def __init__(self):
+        self.logger = logging.getLogger("nplusone")
+
+    def notify(self, message):
+        self.logger.warning("%s", message.message)
+
+
+class _StrictListener(object):
+    def notify(self, message):
+        raise exceptions.NPlusOneError(message.message)
+
+
+class _ReportAndStrictListener(object):
+    def __init__(self, report):
+        self._report = _ReportListener(report)
+        self._strict = _StrictListener()
+
+    def notify(self, message):
+        self._report.notify(message)
+        self._strict.notify(message)
+
+
+def _listeners_enabled(config):
+    return (
+        config.getoption("nplusone", default=False)
+        or config.getoption("nplusone_report", default=False)
+        or config.getoption("nplusone_error", default=False)
+    )
+
+
+class _NplusoneXdistMergePlugin:
+    def pytest_testnodedown(self, node, error):
+        if error is not None:
+            return
+        cfg = getattr(node, "config", None)
+        if cfg is None or not cfg.getoption("nplusone_report", default=False):
+            return
+        payloads = getattr(cfg, "_nplusone_worker_payloads", None)
+        if payloads is None:
+            return
+        wout = getattr(node, "workeroutput", None)
+        if not isinstance(wout, dict) or "nplusone_report_dict" not in wout:
+            return
+        payloads.append(wout["nplusone_report_dict"])
+
+
+def _register_xdist_merge_plugin(config):
+    if not config.getoption("nplusone_report", default=False):
+        return
+    if getattr(config, "_nplusone_xdist_merge_registered", False):
+        return
+    if not config.pluginmanager.hasplugin("xdist"):
+        return
+    config.pluginmanager.register(_NplusoneXdistMergePlugin(), "_nplusone_xdist_merge")
+    config._nplusone_xdist_merge_registered = True
+
+
 def pytest_addoption(parser):
-    group = parser.getgroup('nplusone')
+    group = parser.getgroup("nplusone")
     group.addoption(
-        '--nplusone-report',
-        action='store_true',
+        "--nplusone",
+        action="store_true",
         default=False,
-        dest='nplusone_report',
-        help='Generate an nplusone report of n+1 query issues detected during tests.',
+        dest="nplusone",
+        help=(
+            "Enable nplusone listeners for each test (lazy/eager detection). "
+            "Violations are logged as warnings unless --nplusone-error or "
+            "--nplusone-report is used."
+        ),
     )
     group.addoption(
-        '--nplusone-report-file',
-        action='store',
+        "--nplusone-error",
+        action="store_true",
+        default=False,
+        dest="nplusone_error",
+        help=(
+            "On nplusone violations, raise NPlusOneError (fail the test). "
+            "Can be combined with --nplusone-report (violations are recorded "
+            "then the test fails)."
+        ),
+    )
+    group.addoption(
+        "--nplusone-django",
+        action="store_true",
+        default=False,
+        dest="nplusone_django",
+        help=(
+            "Import the Django ORM integration (nplusone.ext.django). "
+            "Use with --nplusone and/or --nplusone-report when testing Django."
+        ),
+    )
+    group.addoption(
+        "--nplusone-report",
+        action="store_true",
+        default=False,
+        dest="nplusone_report",
+        help="Generate an nplusone report of n+1 query issues detected during tests.",
+    )
+    group.addoption(
+        "--nplusone-report-file",
+        action="store",
         default=None,
-        dest='nplusone_report_file',
-        help='Write the nplusone report to a file (default: print to terminal).',
-    )
-    group.addoption(
-        '--nplusone-report-format',
-        action='store',
-        default='text',
-        dest='nplusone_report_format',
-        choices=['text', 'json'],
-        help='Report output format: text or json (default: text).',
+        dest="nplusone_report_file",
+        help=(
+            "Write the nplusone report to a file (default: print to terminal). "
+            "Format is inferred from the path: names ending in .json are JSON; otherwise plain text."
+        ),
     )
 
 
 def pytest_configure(config):
-    if not config.getoption('nplusone_report', default=False):
+    if config.getoption("nplusone_django", default=False):
+        try:
+            import nplusone.ext.django  # noqa: F401
+        except ImportError as err:
+            raise pytest.UsageError("--nplusone-django requires Django to be installed ({0})".format(err))
+
+    if not _listeners_enabled(config):
         return
-    global _report
-    _report = Report()
-    config._nplusone_report = _report
-    config._nplusone_listener_parent = _ReportListener(_report)
+
+    if config.getoption("nplusone_report", default=False):
+        global _report
+        _report = Report()
+        config._nplusone_report = _report
+        config._nplusone_worker_payloads = []
+        _register_xdist_merge_plugin(config)
+        if config.getoption("nplusone_error", default=False):
+            config._nplusone_listener_parent = _ReportAndStrictListener(_report)
+        else:
+            config._nplusone_listener_parent = _ReportListener(_report)
+    elif config.getoption("nplusone_error", default=False):
+        config._nplusone_report = None
+        config._nplusone_listener_parent = _StrictListener()
+    else:
+        config._nplusone_report = None
+        config._nplusone_listener_parent = _WarnListener()
+
+
+def pytest_sessionstart(session):
+    _register_xdist_merge_plugin(session.config)
 
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_protocol(item, nextitem):
-    report = getattr(item.config, '_nplusone_report', None)
-    if report is None:
+    parent = getattr(item.config, "_nplusone_listener_parent", None)
+    if parent is None:
         yield
         return
 
-    parent = item.config._nplusone_listener_parent
-    report.set_current_test(item.nodeid)
+    _ensure_nplusone_django()
+
+    report = getattr(item.config, "_nplusone_report", None)
+    if report is not None:
+        report.set_current_test(item.nodeid)
+
     active_listeners = {}
     for name, listener_type in listeners.listeners.items():
         active_listeners[name] = listener_type(parent)
@@ -79,29 +222,57 @@ def pytest_runtest_protocol(item, nextitem):
     finally:
         for name in list(active_listeners):
             active_listeners.pop(name).teardown()
-        report.clear_current_test()
+        if report is not None:
+            report.clear_current_test()
 
 
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session, exitstatus):
+    config = session.config
+    if not config.getoption("nplusone_report", default=False):
+        return
+    report = getattr(config, "_nplusone_report", None)
+    if report is None:
+        return
+    workeroutput = getattr(config, "workeroutput", None)
+    if isinstance(workeroutput, dict):
+        workeroutput["nplusone_report_dict"] = report.to_dict()
+
+
+@pytest.hookimpl(trylast=True)
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
-    report = getattr(config, '_nplusone_report', None)
+    if not config.getoption("nplusone_report", default=False):
+        return
+    if _is_xdist_worker(config):
+        return
+
+    report = getattr(config, "_nplusone_report", None)
     if report is None:
         return
 
-    fmt = config.getoption('nplusone_report_format', default='text')
-    outfile = config.getoption('nplusone_report_file', default=None)
+    fmt = _infer_report_format(config)
+    outfile = config.getoption("nplusone_report_file", default=None)
 
-    if fmt == 'json':
-        content = report.to_json(indent=2)
+    payloads = list(getattr(config, "_nplusone_worker_payloads", None) or [])
+    if report.entries:
+        payloads.append(report.to_dict())
+    if payloads:
+        merged = merge_report_dicts(payloads)
+        if fmt == "json":
+            content = json.dumps(merged, indent=2)
+        else:
+            content = report_dict_to_text(merged)
     else:
-        content = report.to_text()
+        if fmt == "json":
+            content = json.dumps({"total_issues": 0, "groups": []}, indent=2)
+        else:
+            content = report_dict_to_text({"total_issues": 0, "groups": []})
 
     if outfile:
-        with open(outfile, 'w') as f:
+        with open(outfile, "w") as f:
             f.write(content)
-            f.write('\n')
-        terminalreporter.write_line(
-            'nplusone report written to: {0}'.format(outfile)
-        )
+            f.write("\n")
+        terminalreporter.write_line("nplusone report written to: {0}".format(outfile))
     else:
-        terminalreporter.write_line('')
+        terminalreporter.write_line("")
         terminalreporter.write_line(content)

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,10 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
+    entry_points={
+        'pytest11': [
+            'nplusone = nplusone.ext.pytest_plugin',
+        ],
+    },
     test_suite='tests'
 )

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -7,12 +7,18 @@ import sys
 import textwrap
 import unittest
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from nplusone.core.report import Report
-from nplusone.ext.pytest_plugin import _ReportListener
+from nplusone.ext.pytest_plugin import _ReportListener, _WarnListener
+
+_NPLUSONE_CLONE_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 class TestReportListener(unittest.TestCase):
-
     def test_notify_adds_to_report(self):
         from nplusone.core.listeners import LazyLoadMessage
 
@@ -21,11 +27,11 @@ class TestReportListener(unittest.TestCase):
 
         report = Report()
         listener = _ReportListener(report)
-        msg = LazyLoadMessage(FakeModel, 'bar')
+        msg = LazyLoadMessage(FakeModel, "bar")
         listener.notify(msg)
         assert len(report) == 1
-        assert report.entries[0].model == 'FakeModel'
-        assert report.entries[0].field == 'bar'
+        assert report.entries[0].model == "FakeModel"
+        assert report.entries[0].field == "bar"
 
     def test_notify_respects_current_test(self):
         from nplusone.core.listeners import LazyLoadMessage
@@ -34,40 +40,63 @@ class TestReportListener(unittest.TestCase):
             pass
 
         report = Report()
-        report.set_current_test('tests/test_x.py::test_y')
+        report.set_current_test("tests/test_x.py::test_y")
         listener = _ReportListener(report)
-        listener.notify(LazyLoadMessage(FakeModel, 'bar'))
-        assert report.entries[0].test_name == 'tests/test_x.py::test_y'
+        listener.notify(LazyLoadMessage(FakeModel, "bar"))
+        assert report.entries[0].test_name == "tests/test_x.py::test_y"
+
+    def test_warn_listener_logs(self):
+        from nplusone.core.listeners import LazyLoadMessage
+
+        class FakeModel(object):
+            __name__ = "FakeModel"
+
+        listener = _WarnListener()
+        with mock.patch.object(listener.logger, "warning") as mock_warning:
+            listener.notify(LazyLoadMessage(FakeModel, "items"))
+        mock_warning.assert_called_once()
+        args, _kwargs = mock_warning.call_args
+        assert any("Potential n+1" in str(a) for a in args)
 
 
 def _run_pytest_subprocess(tmp_dir, test_code, extra_args=None):
-    test_file = os.path.join(tmp_dir, 'test_sample.py')
-    with open(test_file, 'w') as f:
+    test_file = os.path.join(tmp_dir, "test_sample.py")
+    with open(test_file, "w") as f:
         f.write(textwrap.dedent(test_code))
     args = [
-        sys.executable, '-m', 'pytest', test_file,
-        '-p', 'no:cacheprovider',
-        '--override-ini=addopts=',
-        '--no-header',
+        sys.executable,
+        "-m",
+        "pytest",
+        test_file,
+        "-p",
+        "no:cacheprovider",
+        "--override-ini=addopts=",
+        "--no-header",
     ]
     if extra_args:
         args.extend(extra_args)
+    py_path = _NPLUSONE_CLONE_ROOT
+    prev_pp = os.environ.get("PYTHONPATH", "")
+    if prev_pp:
+        py_path = py_path + os.pathsep + prev_pp
     result = subprocess.run(
         args,
         capture_output=True,
         text=True,
         cwd=tmp_dir,
-        env=dict(os.environ, DJANGO_SETTINGS_MODULE=''),
+        env=dict(os.environ, DJANGO_SETTINGS_MODULE="", PYTHONPATH=py_path),
     )
     return result
 
 
 class TestPytestPluginIntegration(unittest.TestCase):
-
     def test_report_text_output(self):
         import tempfile
+
         with tempfile.TemporaryDirectory() as tmp_dir:
-            result = _run_pytest_subprocess(tmp_dir, """
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
                 from nplusone.core import signals
 
                 class Widget(object):
@@ -86,17 +115,22 @@ class TestPytestPluginIntegration(unittest.TestCase):
                         args=None, kwargs=None, context=None, ret=None,
                         parser=lambda a, k, c: (Widget, 'Widget:1', 'parts'),
                     )
-            """, extra_args=['--nplusone-report'])
-            assert 'nplusone Report' in result.stdout
-            assert 'Widget' in result.stdout
-            assert 'parts' in result.stdout
-            assert 'n_plus_one' in result.stdout
+            """,
+                extra_args=["--nplusone-report"],
+            )
+            assert "nplusone Report" in result.stdout
+            assert "Widget" in result.stdout
+            assert "parts" in result.stdout
+            assert "n_plus_one" in result.stdout
 
     def test_report_json_to_file(self):
         import tempfile
+
         with tempfile.TemporaryDirectory() as tmp_dir:
-            outfile = os.path.join(tmp_dir, 'report.json')
-            result = _run_pytest_subprocess(tmp_dir, """
+            outfile = os.path.join(tmp_dir, "report.json")
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
                 from nplusone.core import signals
 
                 class Gadget(object):
@@ -113,35 +147,79 @@ class TestPytestPluginIntegration(unittest.TestCase):
                         args=None, kwargs=None, context=None, ret=None,
                         parser=lambda a, k, c: (Gadget, 'Gadget:1', 'widgets'),
                     )
-            """, extra_args=[
-                '--nplusone-report',
-                '--nplusone-report-format=json',
-                '--nplusone-report-file={0}'.format(outfile),
-            ])
-            assert 'nplusone report written to' in result.stdout
+            """,
+                extra_args=[
+                    "--nplusone-report",
+                    "--nplusone-report-file={0}".format(outfile),
+                ],
+            )
+            assert "nplusone report written to" in result.stdout
             with open(outfile) as f:
                 data = json.load(f)
-            assert data['total_issues'] >= 1
-            group = data['groups'][0]
-            assert group['model'] == 'Gadget'
-            assert group['field'] == 'widgets'
-            assert group['error_type'] == 'n_plus_one'
-            assert len(group['tests']) >= 1
-            assert any('test_trigger' in t for t in group['tests'])
+            assert data["total_issues"] >= 1
+            group = data["groups"][0]
+            assert group["model"] == "Gadget"
+            assert group["field"] == "widgets"
+            assert group["error_type"] == "n_plus_one"
+            assert len(group["tests"]) >= 1
+            assert any("test_trigger" in t for t in group["tests"])
+
+    def test_report_text_to_file_auto_format_from_txt_extension(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            outfile = os.path.join(tmp_dir, "report.txt")
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
+                from nplusone.core import signals
+
+                class Widget(object):
+                    pass
+
+                def test_trigger():
+                    signals.load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c, r: ['Widget:1'],
+                    )
+                    signals.lazy_load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c: (Widget, 'Widget:1', 'parts'),
+                    )
+            """,
+                extra_args=[
+                    "--nplusone-report",
+                    "--nplusone-report-file={0}".format(outfile),
+                ],
+            )
+            assert "nplusone report written to" in result.stdout
+            with open(outfile) as f:
+                body = f.read()
+            assert "nplusone Report" in body
+            assert "Widget" in body
 
     def test_no_flag_no_report(self):
         import tempfile
+
         with tempfile.TemporaryDirectory() as tmp_dir:
-            result = _run_pytest_subprocess(tmp_dir, """
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
                 def test_nothing():
                     pass
-            """)
-            assert 'nplusone Report' not in result.stdout
+            """,
+            )
+            assert "nplusone Report" not in result.stdout
 
     def test_report_includes_test_names(self):
         import tempfile
+
         with tempfile.TemporaryDirectory() as tmp_dir:
-            result = _run_pytest_subprocess(tmp_dir, """
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
                 from nplusone.core import signals
 
                 class Order(object):
@@ -170,16 +248,239 @@ class TestPytestPluginIntegration(unittest.TestCase):
                         args=None, kwargs=None, context=None, ret=None,
                         parser=lambda a, k, c: (Order, 'Order:2', 'items'),
                     )
-            """, extra_args=['--nplusone-report'])
-            assert 'Tests:' in result.stdout
-            assert 'test_first' in result.stdout
-            assert 'test_second' in result.stdout
+            """,
+                extra_args=["--nplusone-report"],
+            )
+            assert "Tests:" in result.stdout
+            assert "test_first" in result.stdout
+            assert "test_second" in result.stdout
 
     def test_empty_report(self):
         import tempfile
+
         with tempfile.TemporaryDirectory() as tmp_dir:
-            result = _run_pytest_subprocess(tmp_dir, """
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
                 def test_clean():
                     pass
-            """, extra_args=['--nplusone-report'])
-            assert 'No n+1 issues detected' in result.stdout
+            """,
+                extra_args=["--nplusone-report"],
+            )
+            assert "No n+1 issues detected" in result.stdout
+
+    def test_nplusone_error_raises(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
+                from nplusone.core import signals
+
+                class StrictModel(object):
+                    pass
+
+                def test_triggers_nplusone():
+                    signals.load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c, r: ['StrictModel:1'],
+                    )
+                    signals.lazy_load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c: (StrictModel, 'StrictModel:1', 'items'),
+                    )
+            """,
+                extra_args=["--nplusone-error"],
+            )
+            assert result.returncode != 0
+            out = result.stdout + result.stderr
+            assert "NPlusOneError" in out or "Potential n+1" in out
+
+    def test_nplusone_warn_only_passes(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
+                from nplusone.core import signals
+
+                class WarnModel(object):
+                    pass
+
+                def test_triggers_nplusone():
+                    signals.load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c, r: ['WarnModel:1'],
+                    )
+                    signals.lazy_load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c: (WarnModel, 'WarnModel:1', 'items'),
+                    )
+            """,
+                extra_args=[
+                    "--nplusone",
+                    "-o",
+                    "log_cli=true",
+                    "-o",
+                    "log_cli_level=WARNING",
+                    "-o",
+                    "log_cli_format=%(message)s",
+                ],
+            )
+            assert result.returncode == 0
+            out = result.stdout + result.stderr
+            assert "Potential n+1" in out
+
+    def test_nplusone_with_error_raises(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
+                from nplusone.core import signals
+
+                class StrictModel(object):
+                    pass
+
+                def test_triggers_nplusone():
+                    signals.load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c, r: ['StrictModel:1'],
+                    )
+                    signals.lazy_load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c: (StrictModel, 'StrictModel:1', 'items'),
+                    )
+            """,
+                extra_args=["--nplusone", "--nplusone-error"],
+            )
+            assert result.returncode != 0
+            out = result.stdout + result.stderr
+            assert "NPlusOneError" in out or "Potential n+1" in out
+
+    def test_nplusone_with_report_combined_flags(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
+                from nplusone.core import signals
+
+                class Widget(object):
+                    pass
+
+                def test_trigger():
+                    signals.load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c, r: ['Widget:1'],
+                    )
+                    signals.lazy_load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c: (Widget, 'Widget:1', 'parts'),
+                    )
+            """,
+                extra_args=["--nplusone", "--nplusone-report"],
+            )
+            assert "nplusone Report" in result.stdout
+            assert "Widget" in result.stdout
+            assert "parts" in result.stdout
+
+    def test_nplusone_report_and_error_fails_test(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
+                from nplusone.core import signals
+
+                class Widget(object):
+                    pass
+
+                def test_trigger():
+                    signals.load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c, r: ['Widget:1'],
+                    )
+                    signals.lazy_load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c: (Widget, 'Widget:1', 'parts'),
+                    )
+            """,
+                extra_args=["--nplusone-report", "--nplusone-error"],
+            )
+            assert result.returncode != 0
+            out = result.stdout + result.stderr
+            assert "Potential n+1" in out or "NPlusOneError" in out
+            assert "Widget" in out
+
+    def test_nplusone_report_django_all_flags(self):
+        try:
+            import django  # noqa: F401
+        except ImportError:
+            self.skipTest("django not installed")
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
+                from nplusone.core import signals
+
+                class Gadget(object):
+                    pass
+
+                def test_trigger():
+                    signals.load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c, r: ['Gadget:1'],
+                    )
+                    signals.lazy_load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c: (Gadget, 'Gadget:1', 'widgets'),
+                    )
+            """,
+                extra_args=[
+                    "--nplusone",
+                    "--nplusone-report",
+                    "--nplusone-django",
+                ],
+            )
+            assert result.returncode == 0
+            assert "nplusone Report" in result.stdout
+            assert "Gadget" in result.stdout
+
+    def test_nplusone_django_only_no_listeners(self):
+        try:
+            import django  # noqa: F401
+        except ImportError:
+            self.skipTest("django not installed")
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
+                def test_clean():
+                    pass
+            """,
+                extra_args=["--nplusone-django"],
+            )
+            assert result.returncode == 0
+            assert "nplusone Report" not in result.stdout

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+
+from nplusone.core.report import Report
+from nplusone.ext.pytest_plugin import _ReportListener
+
+
+class TestReportListener(unittest.TestCase):
+
+    def test_notify_adds_to_report(self):
+        from nplusone.core.listeners import LazyLoadMessage
+
+        class FakeModel(object):
+            pass
+
+        report = Report()
+        listener = _ReportListener(report)
+        msg = LazyLoadMessage(FakeModel, 'bar')
+        listener.notify(msg)
+        assert len(report) == 1
+        assert report.entries[0].model == 'FakeModel'
+        assert report.entries[0].field == 'bar'
+
+    def test_notify_respects_current_test(self):
+        from nplusone.core.listeners import LazyLoadMessage
+
+        class FakeModel(object):
+            pass
+
+        report = Report()
+        report.set_current_test('tests/test_x.py::test_y')
+        listener = _ReportListener(report)
+        listener.notify(LazyLoadMessage(FakeModel, 'bar'))
+        assert report.entries[0].test_name == 'tests/test_x.py::test_y'
+
+
+def _run_pytest_subprocess(tmp_dir, test_code, extra_args=None):
+    test_file = os.path.join(tmp_dir, 'test_sample.py')
+    with open(test_file, 'w') as f:
+        f.write(textwrap.dedent(test_code))
+    args = [
+        sys.executable, '-m', 'pytest', test_file,
+        '-p', 'no:cacheprovider',
+        '--override-ini=addopts=',
+        '--no-header',
+    ]
+    if extra_args:
+        args.extend(extra_args)
+    result = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        cwd=tmp_dir,
+        env=dict(os.environ, DJANGO_SETTINGS_MODULE=''),
+    )
+    return result
+
+
+class TestPytestPluginIntegration(unittest.TestCase):
+
+    def test_report_text_output(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = _run_pytest_subprocess(tmp_dir, """
+                from nplusone.core import signals
+
+                class Widget(object):
+                    pass
+
+                def test_trigger():
+                    # First send a load event to register the instance
+                    signals.load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c, r: ['Widget:1'],
+                    )
+                    # Then send a lazy_load for that instance
+                    signals.lazy_load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c: (Widget, 'Widget:1', 'parts'),
+                    )
+            """, extra_args=['--nplusone-report'])
+            assert 'nplusone Report' in result.stdout
+            assert 'Widget' in result.stdout
+            assert 'parts' in result.stdout
+            assert 'n_plus_one' in result.stdout
+
+    def test_report_json_to_file(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            outfile = os.path.join(tmp_dir, 'report.json')
+            result = _run_pytest_subprocess(tmp_dir, """
+                from nplusone.core import signals
+
+                class Gadget(object):
+                    pass
+
+                def test_trigger():
+                    signals.load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c, r: ['Gadget:1'],
+                    )
+                    signals.lazy_load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c: (Gadget, 'Gadget:1', 'widgets'),
+                    )
+            """, extra_args=[
+                '--nplusone-report',
+                '--nplusone-report-format=json',
+                '--nplusone-report-file={0}'.format(outfile),
+            ])
+            assert 'nplusone report written to' in result.stdout
+            with open(outfile) as f:
+                data = json.load(f)
+            assert data['total_issues'] >= 1
+            group = data['groups'][0]
+            assert group['model'] == 'Gadget'
+            assert group['field'] == 'widgets'
+            assert group['error_type'] == 'n_plus_one'
+            assert len(group['tests']) >= 1
+            assert any('test_trigger' in t for t in group['tests'])
+
+    def test_no_flag_no_report(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = _run_pytest_subprocess(tmp_dir, """
+                def test_nothing():
+                    pass
+            """)
+            assert 'nplusone Report' not in result.stdout
+
+    def test_report_includes_test_names(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = _run_pytest_subprocess(tmp_dir, """
+                from nplusone.core import signals
+
+                class Order(object):
+                    pass
+
+                def test_first():
+                    signals.load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c, r: ['Order:1'],
+                    )
+                    signals.lazy_load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c: (Order, 'Order:1', 'items'),
+                    )
+
+                def test_second():
+                    signals.load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c, r: ['Order:2'],
+                    )
+                    signals.lazy_load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c: (Order, 'Order:2', 'items'),
+                    )
+            """, extra_args=['--nplusone-report'])
+            assert 'Tests:' in result.stdout
+            assert 'test_first' in result.stdout
+            assert 'test_second' in result.stdout
+
+    def test_empty_report(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = _run_pytest_subprocess(tmp_dir, """
+                def test_clean():
+                    pass
+            """, extra_args=['--nplusone-report'])
+            assert 'No n+1 issues detected' in result.stdout

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import glob
 import json
 import os
 import subprocess
@@ -154,7 +155,9 @@ class TestPytestPluginIntegration(unittest.TestCase):
                 ],
             )
             assert "nplusone report written to" in result.stdout
-            with open(outfile) as f:
+            matches = glob.glob(os.path.join(tmp_dir, "report-*.json"))
+            assert len(matches) == 1
+            with open(matches[0]) as f:
                 data = json.load(f)
             assert data["total_issues"] >= 1
             group = data["groups"][0]
@@ -195,10 +198,94 @@ class TestPytestPluginIntegration(unittest.TestCase):
                 ],
             )
             assert "nplusone report written to" in result.stdout
-            with open(outfile) as f:
+            matches = glob.glob(os.path.join(tmp_dir, "report-*.txt"))
+            assert len(matches) == 1
+            with open(matches[0]) as f:
                 body = f.read()
             assert "nplusone Report" in body
             assert "Widget" in body
+
+    def test_report_json_file_suffix_template(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            pattern = os.path.join(tmp_dir, "nplusone-{suffix}.json")
+            result = _run_pytest_subprocess(
+                tmp_dir,
+                """
+                from nplusone.core import signals
+
+                class Gadget(object):
+                    pass
+
+                def test_trigger():
+                    signals.load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c, r: ['Gadget:1'],
+                    )
+                    signals.lazy_load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c: (Gadget, 'Gadget:1', 'widgets'),
+                    )
+            """,
+                extra_args=[
+                    "--nplusone-report",
+                    "--nplusone-report-file={0}".format(pattern),
+                ],
+            )
+            assert result.returncode == 0
+            matches = glob.glob(os.path.join(tmp_dir, "nplusone-*.json"))
+            assert len(matches) == 1
+            assert "{suffix}" not in matches[0]
+            with open(matches[0]) as f:
+                data = json.load(f)
+            assert data["total_issues"] >= 1
+
+    def test_report_file_auto_suffix_two_runs_no_clobber(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base = os.path.join(tmp_dir, "out.json")
+            snippet = """
+                from nplusone.core import signals
+
+                class G(object):
+                    pass
+
+                def test_t():
+                    signals.load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c, r: ['G:1'],
+                    )
+                    signals.lazy_load.send(
+                        signals.get_worker(),
+                        args=None, kwargs=None, context=None, ret=None,
+                        parser=lambda a, k, c: (G, 'G:1', 'x'),
+                    )
+            """
+            r1 = _run_pytest_subprocess(
+                tmp_dir,
+                snippet,
+                extra_args=[
+                    "--nplusone-report",
+                    "--nplusone-report-file={0}".format(base),
+                ],
+            )
+            r2 = _run_pytest_subprocess(
+                tmp_dir,
+                snippet,
+                extra_args=[
+                    "--nplusone-report",
+                    "--nplusone-report-file={0}".format(base),
+                ],
+            )
+            assert r1.returncode == 0
+            assert r2.returncode == 0
+            matches = glob.glob(os.path.join(tmp_dir, "out-*.json"))
+            assert len(matches) == 2
 
     def test_no_flag_no_report(self):
         import tempfile

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+
+import json
+import unittest
+
+from nplusone.core.listeners import LazyLoadMessage, EagerLoadMessage
+from nplusone.core.report import Report, ReportEntry
+from nplusone.core.notifiers import ReportNotifier
+from nplusone.core.profiler import Profiler
+
+
+class FakeModel(object):
+    __name__ = 'FakeModel'
+
+
+class OtherModel(object):
+    __name__ = 'OtherModel'
+
+
+class TestReportEntry(unittest.TestCase):
+
+    def test_group_key(self):
+        msg = LazyLoadMessage(FakeModel, 'items')
+        caller = ('/app/views.py', '/app/views.py', 42, 'get_items', None, None)
+        entry = ReportEntry(msg, caller)
+        assert entry.group_key == ('FakeModel', 'items', 'n_plus_one', 'get_items')
+
+    def test_group_key_no_caller(self):
+        msg = LazyLoadMessage(FakeModel, 'items')
+        entry = ReportEntry(msg, caller=None)
+        assert entry.group_key == ('FakeModel', 'items', 'n_plus_one', 'unknown')
+
+    def test_parse_caller(self):
+        caller = ('/app/views.py', '/app/views.py', 42, 'get_items', None, None)
+        entry = ReportEntry(LazyLoadMessage(FakeModel, 'items'), caller)
+        assert entry.caller == {
+            'filename': '/app/views.py',
+            'lineno': 42,
+            'function': 'get_items',
+        }
+
+    def test_parse_caller_none(self):
+        entry = ReportEntry(LazyLoadMessage(FakeModel, 'items'), None)
+        assert entry.caller is None
+
+    def test_stores_message_fields(self):
+        msg = EagerLoadMessage(FakeModel, 'related')
+        entry = ReportEntry(msg)
+        assert entry.model == 'FakeModel'
+        assert entry.field == 'related'
+        assert entry.label == 'unused_eager_load'
+        assert 'FakeModel.related' in entry.message
+
+    def test_stores_test_name(self):
+        msg = LazyLoadMessage(FakeModel, 'items')
+        entry = ReportEntry(msg, test_name='test_foo::test_bar')
+        assert entry.test_name == 'test_foo::test_bar'
+
+    def test_test_name_defaults_none(self):
+        msg = LazyLoadMessage(FakeModel, 'items')
+        entry = ReportEntry(msg)
+        assert entry.test_name is None
+
+
+class TestReport(unittest.TestCase):
+
+    def test_empty_report(self):
+        report = Report()
+        assert len(report) == 0
+        assert not report
+        assert report.aggregated == []
+        assert report.to_text() == 'No n+1 issues detected.'
+
+    def test_add_entries(self):
+        report = Report()
+        msg1 = LazyLoadMessage(FakeModel, 'items')
+        msg2 = LazyLoadMessage(FakeModel, 'items')
+        report.add(msg1)
+        report.add(msg2)
+        assert len(report) == 2
+        assert report
+
+    def test_aggregation_groups_by_key(self):
+        report = Report()
+        caller1 = (None, '/app/views.py', 10, 'list_view', None, None)
+        caller2 = (None, '/app/views.py', 10, 'list_view', None, None)
+        caller3 = (None, '/app/views.py', 20, 'detail_view', None, None)
+
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller1)
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller2)
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller3)
+
+        agg = report.aggregated
+        assert len(agg) == 2
+
+        list_group = next(g for g in agg if g['caller'] == 'list_view')
+        assert list_group['count'] == 2
+        assert list_group['model'] == 'FakeModel'
+        assert list_group['field'] == 'items'
+        assert list_group['error_type'] == 'n_plus_one'
+
+        detail_group = next(g for g in agg if g['caller'] == 'detail_view')
+        assert detail_group['count'] == 1
+
+    def test_aggregation_different_error_types(self):
+        report = Report()
+        caller = (None, '/app/views.py', 10, 'list_view', None, None)
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        report.add(EagerLoadMessage(FakeModel, 'items'), caller)
+        agg = report.aggregated
+        assert len(agg) == 2
+
+    def test_aggregation_different_models(self):
+        report = Report()
+        caller = (None, '/app/views.py', 10, 'list_view', None, None)
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        report.add(LazyLoadMessage(OtherModel, 'items'), caller)
+        agg = report.aggregated
+        assert len(agg) == 2
+
+    def test_aggregation_different_fields(self):
+        report = Report()
+        caller = (None, '/app/views.py', 10, 'list_view', None, None)
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        report.add(LazyLoadMessage(FakeModel, 'widgets'), caller)
+        agg = report.aggregated
+        assert len(agg) == 2
+
+    def test_aggregation_locations_deduped(self):
+        report = Report()
+        caller = (None, '/app/views.py', 10, 'list_view', None, None)
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        agg = report.aggregated
+        assert len(agg[0]['locations']) == 1
+        assert agg[0]['locations'] == ['/app/views.py:10']
+
+    def test_aggregation_includes_tests(self):
+        report = Report()
+        caller = (None, '/app/views.py', 10, 'list_view', None, None)
+        report.set_current_test('tests/test_foo.py::test_bar')
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        report.set_current_test('tests/test_foo.py::test_baz')
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        report.clear_current_test()
+        agg = report.aggregated
+        assert len(agg) == 1
+        assert agg[0]['tests'] == [
+            'tests/test_foo.py::test_bar',
+            'tests/test_foo.py::test_baz',
+        ]
+
+    def test_aggregation_dedupes_tests(self):
+        report = Report()
+        caller = (None, '/app/views.py', 10, 'list_view', None, None)
+        report.set_current_test('tests/test_foo.py::test_bar')
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        agg = report.aggregated
+        assert agg[0]['tests'] == ['tests/test_foo.py::test_bar']
+
+    def test_aggregation_no_test_name(self):
+        report = Report()
+        caller = (None, '/app/views.py', 10, 'list_view', None, None)
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        agg = report.aggregated
+        assert agg[0]['tests'] == []
+
+    def test_to_text_empty(self):
+        report = Report()
+        assert report.to_text() == 'No n+1 issues detected.'
+
+    def test_to_text_with_entries(self):
+        report = Report()
+        caller = (None, '/app/views.py', 10, 'list_view', None, None)
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        text = report.to_text()
+        assert 'nplusone Report' in text
+        assert 'Total issues: 1' in text
+        assert 'FakeModel' in text
+        assert 'items' in text
+        assert 'n_plus_one' in text
+        assert 'list_view' in text
+        assert '/app/views.py:10' in text
+
+    def test_to_text_with_tests(self):
+        report = Report()
+        caller = (None, '/app/views.py', 10, 'list_view', None, None)
+        report.set_current_test('tests/test_foo.py::test_bar')
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        report.clear_current_test()
+        text = report.to_text()
+        assert 'Tests:' in text
+        assert 'tests/test_foo.py::test_bar' in text
+
+    def test_to_dict(self):
+        report = Report()
+        caller = (None, '/app/views.py', 10, 'list_view', None, None)
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        d = report.to_dict()
+        assert d['total_issues'] == 1
+        assert len(d['groups']) == 1
+        group = d['groups'][0]
+        assert group['model'] == 'FakeModel'
+        assert group['field'] == 'items'
+        assert group['error_type'] == 'n_plus_one'
+        assert group['caller'] == 'list_view'
+        assert group['count'] == 1
+        assert group['tests'] == []
+
+    def test_to_json(self):
+        report = Report()
+        caller = (None, '/app/views.py', 10, 'list_view', None, None)
+        report.add(LazyLoadMessage(FakeModel, 'items'), caller)
+        j = report.to_json()
+        data = json.loads(j)
+        assert data['total_issues'] == 1
+        assert data['groups'][0]['model'] == 'FakeModel'
+
+    def test_bool_empty(self):
+        report = Report()
+        assert not report
+
+    def test_bool_non_empty(self):
+        report = Report()
+        report.add(LazyLoadMessage(FakeModel, 'items'))
+        assert report
+
+    def test_set_and_clear_current_test(self):
+        report = Report()
+        assert report._current_test is None
+        report.set_current_test('test_foo')
+        assert report._current_test == 'test_foo'
+        report.add(LazyLoadMessage(FakeModel, 'items'))
+        assert report.entries[0].test_name == 'test_foo'
+        report.clear_current_test()
+        assert report._current_test is None
+        report.add(LazyLoadMessage(FakeModel, 'items'))
+        assert report.entries[1].test_name is None
+
+
+class TestReportNotifier(unittest.TestCase):
+
+    def test_is_enabled_default(self):
+        assert not ReportNotifier.is_enabled({})
+
+    def test_is_enabled_when_configured(self):
+        assert ReportNotifier.is_enabled({'NPLUSONE_REPORT': True})
+
+    def test_notify_adds_to_report(self):
+        report = Report()
+        notifier = ReportNotifier({'NPLUSONE_REPORT_OBJECT': report})
+        msg = LazyLoadMessage(FakeModel, 'items')
+        notifier.notify(msg)
+        assert len(report) == 1
+        assert report.entries[0].model == 'FakeModel'
+        assert report.entries[0].field == 'items'
+
+    def test_uses_provided_report(self):
+        report = Report()
+        notifier = ReportNotifier({'NPLUSONE_REPORT_OBJECT': report})
+        assert notifier.report is report
+
+    def test_creates_default_report(self):
+        notifier = ReportNotifier({})
+        assert isinstance(notifier.report, Report)
+
+
+class TestProfilerReport(unittest.TestCase):
+
+    def test_profiler_collects_to_report(self):
+        report = Report()
+        profiler = Profiler(report=report)
+        msg = LazyLoadMessage(FakeModel, 'items')
+        profiler.notify(msg)
+        assert len(report) == 1
+
+    def test_profiler_without_report_raises(self):
+        profiler = Profiler()
+        msg = LazyLoadMessage(FakeModel, 'items')
+        from nplusone.core.exceptions import NPlusOneError
+        with self.assertRaises(NPlusOneError):
+            profiler.notify(msg)
+
+    def test_profiler_enter_returns_self(self):
+        profiler = Profiler()
+        result = profiler.__enter__()
+        assert result is profiler
+        profiler.__exit__(None, None, None)
+
+    def test_profiler_context_manager_with_report(self):
+        report = Report()
+        with Profiler(report=report) as p:
+            assert p.report is report
+
+    def test_profiler_report_respects_whitelist(self):
+        report = Report()
+        profiler = Profiler(
+            whitelist=[{'model': 'FakeModel', 'field': 'items'}],
+            report=report,
+        )
+        msg = LazyLoadMessage(FakeModel, 'items')
+        profiler.notify(msg)
+        assert len(report) == 0


### PR DESCRIPTION
## Summary

Adds aggregated **reports** for n+1 / unnecessary eager-load detections, a **pytest plugin** (listeners, optional strict failure, terminal or file output, **pytest-xdist** merge), **Profiler** support for recording into a `Report` instead of only raising, and **ReportNotifier** for Django/Flask when `NPLUSONE_REPORT` is enabled. `README.rst` documents flags and usage.

## What’s included

- **`Report`**: groups by model, field, error type, and caller; counts, locations, `to_text` / `to_dict` / `to_json`; `merge_report_dicts` for distributed runs.
- **Pytest**: `--nplusone`, `--nplusone-error`, `--nplusone-report`, `--nplusone-report-file` (`.json` vs text by extension), `--nplusone-django`; registered via `pytest11` in `setup.py`.
- **Profiler**: optional `report=` to collect issues without raising.
- **Frameworks**: `ReportNotifier` + `NPLUSONE_REPORT` / `NPLUSONE_REPORT_OBJECT` (and optional caller patterns).

## Pytest behavior

- **`--nplusone`**: listeners per test; violations log as warnings unless error/report modes apply.
- **`--nplusone-report`**: builds a session report (terminal text by default, or `--nplusone-report-file`). Implies collecting violations for aggregation.
- **`--nplusone-error`**: fail with `NPlusOneError`. Can combine with `--nplusone-report` so the issue is recorded before the failure.
- **`--nplusone-django`**: import `nplusone.ext.django` when Django is available (needed for Django ORM tests).
- **`--nplusone-report-file`** Specify an output filename for report
- **pytest-xdist**: worker reports are merged on the controller before printing or writing the file.

Example commands:

```bash
pytest --nplusone --nplusone-report --nplusone-django
pytest --nplusone --nplusone-error
pytest --nplusone-report --nplusone-report-file=report.json
pytest --nplusone-report --nplusone-report-file=report.txt
```

## Profiler and apps

Use `Profiler(report=report)` with a shared `Report` to profile arbitrary code paths (scripts, management commands, etc.) and emit the same text/JSON as pytest. For request-scoped apps, enable `NPLUSONE_REPORT` and pass a shared `Report` via `NPLUSONE_REPORT_OBJECT` so middleware-driven detections land in one object you can inspect after the request.

## Example report (text)

```
nplusone Report
============================================================
Total issues: 9
Unique groups: 3

1. Potential n+1 query detected on `User.hobbies`
   Model:      User
   Field:      hobbies
   Error type: n_plus_one
   Caller:     test_n_plus_one_on_hobbies
   Count:      3
   Locations:
     - /app/example_tests.py:44
   Tests:
     - example_tests.py::test_n_plus_one_on_hobbies
```

When nothing is detected, the text report is a single line: `No n+1 issues detected.` (JSON uses `"total_issues": 0` and `"groups": []`).

## Example report (JSON, one group)

```json
{
  "total_issues": 3,
  "groups": [
    {
      "model": "User",
      "field": "hobbies",
      "error_type": "n_plus_one",
      "caller": "test_n_plus_one_on_hobbies",
      "count": 3,
      "message": "Potential n+1 query detected on `User.hobbies`",
      "locations": ["/app/example_tests.py:44"],
      "tests": ["example_tests.py::test_n_plus_one_on_hobbies"]
    }
  ]
}
```

## Tests

Adds `tests/test_report.py` and `tests/test_pytest_plugin.py` for aggregation, serialization, CLI, file output, and xdist merging.

## Links

- Asana: <!-- ... -->
- TAD: <!-- ... -->
